### PR TITLE
Add privacy-conscious submission example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ uploads/*
 *.db
 venv/
 /backend/__pycache__
+data/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Supplementary Test Kit
+
+This repository provides a minimal example of handling user submissions while respecting privacy.
+
+## Features
+
+1. **HTTPS Required**: The server is configured to run with a self-signed certificate in development. In production, run behind an HTTPS reverse proxy.
+2. **User Consent**: The HTML form includes a mandatory consent checkbox linking to the privacy policy.
+3. **Minimal Data Storage**: Only name, a hashed version of the email, and an optional comment are stored.
+4. **Pseudonymization**: Email addresses are hashed before storage to reduce the risk of identifying individuals.
+
+## Running
+
+Install the dependencies (Flask) and run the server:
+
+```bash
+pip install Flask
+python server.py
+```
+
+Then open `https://localhost:5000/` in your browser. You may need to accept a self-signed certificate.
+
+## Privacy Policy
+
+Edit `static/privacy_policy.html` with the details of your actual policy.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,49 @@
+import hashlib
+import json
+from pathlib import Path
+from flask import Flask, request, redirect, send_from_directory, abort
+
+app = Flask(__name__)
+
+DATA_PATH = Path('data/submissions.json')
+DATA_PATH.parent.mkdir(exist_ok=True)
+DATA_PATH.touch(exist_ok=True)
+
+@app.route('/')
+def index():
+    return send_from_directory('static', 'index.html')
+
+@app.route('/privacy_policy.html')
+def privacy_policy():
+    return send_from_directory('static', 'privacy_policy.html')
+
+@app.route('/submit', methods=['POST'])
+def submit():
+    # Ensure consent was provided
+    if not request.form.get('consent'):
+        abort(400, 'Consent is required')
+
+    # Only store fields that are necessary
+    name = request.form.get('name')
+    email = request.form.get('email')
+    comment = request.form.get('comment')
+
+    # Pseudonymize email by hashing
+    email_hash = hashlib.sha256(email.encode('utf-8')).hexdigest()
+
+    record = {
+        'name': name,
+        'email_hash': email_hash,
+        'comment': comment
+    }
+
+    with open(DATA_PATH, 'a') as f:
+        json.dump(record, f)
+        f.write('\n')
+
+    return 'Submission received. Thank you!'
+
+if __name__ == '__main__':
+    # Use SSL context for HTTPS in development. In production, run behind a
+    # reverse proxy that terminates TLS.
+    app.run(ssl_context='adhoc')

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sample Submission Form</title>
+</head>
+<body>
+    <h1>Submit Your Information</h1>
+    <form action="/submit" method="POST">
+        <label for="name">Name:</label><br>
+        <input type="text" id="name" name="name" required><br><br>
+        <label for="email">Email:</label><br>
+        <input type="email" id="email" name="email" required><br><br>
+        <label for="comment">Comment:</label><br>
+        <textarea id="comment" name="comment" rows="4" cols="50"></textarea><br><br>
+        <label>
+            <input type="checkbox" name="consent" required>
+            I agree to the <a href="/privacy_policy.html" target="_blank">Privacy Policy</a>
+        </label><br><br>
+        <button type="submit">Submit</button>
+    </form>
+</body>
+</html>

--- a/static/privacy_policy.html
+++ b/static/privacy_policy.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Privacy Policy</title>
+</head>
+<body>
+    <h1>Privacy Policy</h1>
+    <p>This is a placeholder privacy policy. Replace this text with your actual policy.
+       It should describe what personal data you collect, why you collect it, how long
+       you keep it, and how users can request deletion.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide minimal Flask server
- add privacy policy and consent form
- hash emails before storage
- document running instructions

## Testing
- `python -m py_compile server.py`
