### PR TITLE
fix: Add console logging to debug URIError on thank_you.html

### DIFF
--- a/static/thank_you.html
+++ b/static/thank_you.html
@@ -62,6 +62,8 @@
 
         if (dataParam) {
             try {
+                console.log("Raw dataParam from URL:", dataParam); // ADDED
+                console.log("Length of dataParam:", dataParam.length); // ADDED
                 const decodedData = decodeURIComponent(dataParam);
                 const answers = JSON.parse(decodedData);
 


### PR DESCRIPTION
This commit updates `static/thank_you.html` to include `console.log` statements for the raw 'data' query parameter and its length. This is intended to help diagnose a `URIError: URI malformed` that occurs during the
`decodeURIComponent` process on this page.