### PR TITLE
Implement admin auth and improve results display

### DIFF
--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    <h1>Admin Dashboard</h1>
+    <ul>
+        <li><a href="{{ url_for('admin_results') }}">View Results</a></li>
+        <li><a href="{{ url_for('admin_group_info') }}">Edit Group Info</a></li>
+        <li><a href="{{ url_for('logout') }}">Logout</a></li>
+    </ul>
+</div>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    <h1>Admin Login</h1>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <div class="form-group">
+            <label>Username</label>
+            <input type="text" name="username">
+        </div>
+        <div class="form-group">
+            <label>Password</label>
+            <input type="password" name="password">
+        </div>
+        <button type="submit">Login</button>
+    </form>
+    <p><a href="{{ url_for('google_auth') }}">Login with Google</a></p>
+</div>
+</body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -63,9 +63,17 @@
 <body>
     <div class="container">
         <h1>Survey Submissions</h1>
+        {% if totals %}
+        <div>
+            <strong>Aggregate Scores:</strong>
+            G1 {{ totals['G1'] }} | G2 {{ totals['G2'] }} | G3 {{ totals['G3'] }} |
+            G4 {{ totals['G4'] }} | G5 {{ totals['G5'] }} | G6 {{ totals['G6'] }}
+        </div>
+        {% endif %}
+        <input type="text" id="filterInput" placeholder="Filter results" style="margin-top:10px;">
 
         {% if results %}
-            <table>
+            <table id="resultsTable">
                 <thead>
                     <tr>
                         <!-- Dynamically generate headers from the first result's keys, if all results have same keys -->
@@ -151,5 +159,30 @@
             <p>No survey results found.</p>
         {% endif %}
     </div>
+    <script>
+    const filterInput = document.getElementById('filterInput');
+    const table = document.getElementById('resultsTable');
+
+    function filterRows() {
+        const query = filterInput.value.toLowerCase();
+        const rows = table.querySelectorAll('tbody tr');
+        rows.forEach(r => {
+            const text = r.textContent.toLowerCase();
+            r.style.display = text.includes(query) ? '' : 'none';
+        });
+    }
+
+    filterInput.addEventListener('input', filterRows);
+
+    table.querySelectorAll('th').forEach((th, idx) => {
+        th.addEventListener('click', () => {
+            const rows = Array.from(table.querySelectorAll('tbody tr'));
+            const sorted = rows.sort((a, b) => a.children[idx].textContent.localeCompare(b.children[idx].textContent));
+            const tbody = table.querySelector('tbody');
+            tbody.innerHTML = '';
+            sorted.forEach(r => tbody.appendChild(r));
+        });
+    });
+    </script>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,7 @@ def test_submit_and_admin_results(client):
     data = res.get_json()
     assert data.get("status") == "success"
     assert "id" in data
+    client.post('/login', data={'username': 'admin', 'password': 'admin'})
     res_admin = client.get('/admin/results')
     assert res_admin.status_code == 200
     assert b'Survey Submissions' in res_admin.data


### PR DESCRIPTION
## Summary
- add session-based admin login with default credentials
- add placeholder Google OAuth route
- require login for admin endpoints
- create admin dashboard template
- add filterable sortable results table with aggregate info
- adjust tests for login requirement
- ensure database initialization doesn't drop existing data

## Testing
- `python -m pytest -q`