### PR TITLE
Implement CSV export and analysis charts

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -119,6 +119,20 @@ button.btn-secondary {
     color: #333;
 }
 
+a.btn-secondary {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    background-color: #bdc3c7;
+    color: #333;
+    border-radius: 6px;
+    text-decoration: none;
+}
+
+a.btn-secondary:hover {
+    background-color: #95a5a6;
+    color: #333;
+}
+
 button.btn-secondary:hover {
     background-color: #95a5a6; /* Darker gray on hover */
 }

--- a/templates/results.html
+++ b/templates/results.html
@@ -64,6 +64,10 @@
 <body>
     <div class="container">
         <h1>Survey Submissions</h1>
+        <div style="text-align:right; margin-bottom:10px;">
+            <a href="{{ url_for('logout') }}" class="btn-secondary">Logout</a>
+            <a href="{{ url_for('admin_export_csv') }}" class="btn-secondary">Export CSV</a>
+        </div>
         {% if totals %}
         <div>
             <strong>Aggregate Scores:</strong>
@@ -97,7 +101,16 @@
         {% else %}
             <p>No survey results found.</p>
         {% endif %}
+
+        <div style="margin-top:40px;">
+            <canvas id="categoryChart" height="150"></canvas>
+        </div>
+        <div style="margin-top:40px;">
+            <canvas id="questionChart" height="150"></canvas>
+        </div>
+        <div id="freeTextContainer" style="margin-top:40px;"></div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
     const filterInput = document.getElementById('filterInput');
     const table = document.getElementById('resultsTable');
@@ -122,6 +135,58 @@
             sorted.forEach(r => tbody.appendChild(r));
         });
     });
+
+    const categoryData = {{ totals | tojson }};
+    const ctxCat = document.getElementById('categoryChart').getContext('2d');
+    new Chart(ctxCat, {
+        type: 'line',
+        data: {
+            labels: Object.keys(categoryData),
+            datasets: [{
+                label: 'Category Scores',
+                data: Object.values(categoryData),
+                fill: true,
+                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                borderColor: 'rgb(75, 192, 192)'
+            }]
+        },
+        options: {responsive: true}
+    });
+
+    const questionCounts = {{ question_counts | tojson }};
+    const labels = Object.keys(questionCounts).map(k => 'Q'+k);
+    const qTotals = labels.map((_, idx) => {
+        const counts = Object.values(questionCounts[Object.keys(questionCounts)[idx]] || {});
+        return counts.reduce((a, b) => a + b, 0);
+    });
+    const ctxQ = document.getElementById('questionChart').getContext('2d');
+    new Chart(ctxQ, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: 'Responses per Question',
+                data: qTotals,
+                fill: true,
+                backgroundColor: 'rgba(153,102,255,0.2)',
+                borderColor: 'rgb(153,102,255)'
+            }]
+        },
+        options: {responsive: true}
+    });
+
+    const freeTexts = {{ free_texts | tojson }};
+    if (freeTexts.length) {
+        const container = document.getElementById('freeTextContainer');
+        const list = document.createElement('ul');
+        freeTexts.forEach(t => {
+            const li = document.createElement('li');
+            li.textContent = t;
+            list.appendChild(li);
+        });
+        container.innerHTML = '<h3>Free Text Responses</h3>';
+        container.appendChild(list);
+    }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow exporting survey results to CSV
- show category totals and per-question counts in area charts
- list free-text responses on results page
- add logout link to results page
- style anchor elements as secondary buttons

## Testing
- `pytest -q`