### PR TITLE
Implement CSV export and analysis charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 import os
 import sqlite3
+import csv
 import json # Added json import
-from flask import Flask, request, jsonify, send_from_directory, render_template, session, redirect, url_for
+from flask import Flask, request, jsonify, send_from_directory, render_template, session, redirect, url_for, Response
 import openai
 
 try:
@@ -327,6 +328,8 @@ def admin_results():
     q_map = {str(q["id"]): q.get("questionText", {}).get("en", f"Q{q['id']}")
              for q in structure.get("questions", [])}
     aggregate_scores = {"G1": 0, "G2": 0, "G3": 0, "G4": 0, "G5": 0, "G6": 0}
+    question_counts = {str(q["id"]): {} for q in structure.get("questions", [])}
+    free_texts = []
     processed_results = []
     for row in results:
         row_dict = dict(row)
@@ -344,15 +347,77 @@ def admin_results():
         row_dict.update(scores)
         for g in aggregate_scores:
             aggregate_scores[g] += scores[g]
+        for q in structure.get("questions", []):
+            qid = str(q.get("id"))
+            val = answers.get(qid)
+            if q.get("type") == "freetext":
+                if val:
+                    free_texts.append(val)
+            elif q.get("type") == "checkbox_group":
+                if isinstance(val, list):
+                    for choice in val:
+                        question_counts[qid][choice] = question_counts[qid].get(choice, 0) + 1
+            else:
+                if val is not None:
+                    question_counts[qid][val] = question_counts[qid].get(val, 0) + 1
         processed_results.append(row_dict)
 
     headers = ["timestamp", "id"] + [f"Q{qid}" for qid in q_map.keys()] + list(aggregate_scores.keys())
+    averages = {g: (aggregate_scores[g]/len(results) if results else 0) for g in aggregate_scores}
     return render_template(
         'results.html',
         results=processed_results,
         totals=aggregate_scores,
+        averages=averages,
         headers=headers,
-        q_map=q_map
+        q_map=q_map,
+        question_counts=question_counts,
+        free_texts=free_texts
+    )
+
+
+@app.route('/admin/export_csv')
+@admin_required
+def admin_export_csv():
+    """Export all survey results as a CSV file."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM responses ORDER BY timestamp DESC")
+    results = cur.fetchall()
+    conn.close()
+
+    structure = _load_questionnaire_structure()
+    q_map = {str(q["id"]): q.get("questionText", {}).get("en", f"Q{q['id']}")
+             for q in structure.get("questions", [])}
+    headers = ["timestamp", "id"] + [f"Q{qid}" for qid in q_map.keys()]
+    headers += ["G1", "G2", "G3", "G4", "G5", "G6"]
+
+    from io import StringIO
+    output_io = StringIO()
+    writer = csv.writer(output_io)
+
+    writer.writerow(headers)
+    for row in results:
+        row_dict = dict(row)
+        answers = {}
+        if row_dict.get("answers_json"):
+            try:
+                answers = json.loads(row_dict["answers_json"])
+            except json.JSONDecodeError:
+                answers = {}
+        scores, _ = _calculate_scores(answers, structure)
+        values = [row_dict["timestamp"], row_dict["id"]]
+        for qid in q_map.keys():
+            values.append(answers.get(str(qid), ""))
+        values.extend([scores[g] for g in ["G1", "G2", "G3", "G4", "G5", "G6"]])
+        writer.writerow(values)
+
+    csv_data = output_io.getvalue()
+    return Response(
+        csv_data,
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=results.csv"}
     )
 
 @app.route('/admin/group_info', methods=['GET', 'POST'])

--- a/static/style.css
+++ b/static/style.css
@@ -119,6 +119,20 @@ button.btn-secondary {
     color: #333;
 }
 
+a.btn-secondary {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    background-color: #bdc3c7;
+    color: #333;
+    border-radius: 6px;
+    text-decoration: none;
+}
+
+a.btn-secondary:hover {
+    background-color: #95a5a6;
+    color: #333;
+}
+
 button.btn-secondary:hover {
     background-color: #95a5a6; /* Darker gray on hover */
 }
@@ -148,6 +162,14 @@ button.btn-secondary:hover {
     background-color: #3498db; /* Primary color */
     border-radius: 4px;
     transition: width 0.4s ease;
+}
+
+/* Chart container for admin results */
+.chart-container {
+    width: 50%;
+    margin: 0 auto;
+    resize: both;
+    overflow: auto;
 }
 
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -64,11 +64,23 @@
 <body>
     <div class="container">
         <h1>Survey Submissions</h1>
+        <div style="text-align:right; margin-bottom:10px;">
+            <a href="{{ url_for('logout') }}" class="btn-secondary">Logout</a>
+            <a href="{{ url_for('admin_export_csv') }}" class="btn-secondary">Export CSV</a>
+        </div>
         {% if totals %}
         <div>
             <strong>Aggregate Scores:</strong>
             G1 {{ totals['G1'] }} | G2 {{ totals['G2'] }} | G3 {{ totals['G3'] }} |
             G4 {{ totals['G4'] }} | G5 {{ totals['G5'] }} | G6 {{ totals['G6'] }}
+        </div>
+        {% endif %}
+        {% if averages %}
+        <div style="margin-top:5px;">
+            <strong>Average Scores:</strong>
+            G1 {{ '%.2f'|format(averages['G1']) }} | G2 {{ '%.2f'|format(averages['G2']) }} |
+            G3 {{ '%.2f'|format(averages['G3']) }} | G4 {{ '%.2f'|format(averages['G4']) }} |
+            G5 {{ '%.2f'|format(averages['G5']) }} | G6 {{ '%.2f'|format(averages['G6']) }}
         </div>
         {% endif %}
         <input type="text" id="filterInput" placeholder="Filter results" style="margin-top:10px;">
@@ -97,7 +109,19 @@
         {% else %}
             <p>No survey results found.</p>
         {% endif %}
+
+        <h3>Category Totals</h3>
+        <div class="chart-container" style="margin-top:20px;">
+            <canvas id="categoryChart" height="150"></canvas>
+        </div>
+        <h3 style="margin-top:40px;">Responses per Question</h3>
+        <div class="chart-container" style="margin-top:20px;">
+            <canvas id="questionChart" height="150"></canvas>
+        </div>
+        <div id="freeTextContainer" style="margin-top:40px;"></div>
+        <div id="analysisSuggestions" style="margin-top:40px;"></div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
     const filterInput = document.getElementById('filterInput');
     const table = document.getElementById('resultsTable');
@@ -122,6 +146,75 @@
             sorted.forEach(r => tbody.appendChild(r));
         });
     });
+
+    const categoryData = {{ totals | tojson }};
+    const ctxCat = document.getElementById('categoryChart').getContext('2d');
+    new Chart(ctxCat, {
+        type: 'line',
+        data: {
+            labels: Object.keys(categoryData),
+            datasets: [{
+                label: 'Category Scores',
+                data: Object.values(categoryData),
+                fill: true,
+                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                borderColor: 'rgb(75, 192, 192)'
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: { title: { display: true, text: 'Category Totals' } }
+        }
+    });
+
+    const questionCounts = {{ question_counts | tojson }};
+    const qLabels = Object.keys(questionCounts).map(k => 'Q' + k);
+    const allAnswers = new Set();
+    Object.values(questionCounts).forEach(obj => {
+        Object.keys(obj).forEach(k => allAnswers.add(k));
+    });
+    const answerList = Array.from(allAnswers);
+    const colors = ['#e74c3c','#3498db','#f1c40f','#2ecc71','#9b59b6','#e67e22','#1abc9c'];
+    function pickColor(i){ return colors[i % colors.length]; }
+    const datasets = answerList.map((ans, idx) => ({
+        label: ans,
+        data: qLabels.map((_, qidx) => {
+            const qid = Object.keys(questionCounts)[qidx];
+            return questionCounts[qid][ans] || 0;
+        }),
+        backgroundColor: pickColor(idx)
+    }));
+    const ctxQ = document.getElementById('questionChart').getContext('2d');
+    new Chart(ctxQ, {
+        type: 'bar',
+        data: { labels: qLabels, datasets: datasets },
+        options: {
+            responsive: true,
+            plugins: { title: { display: true, text: 'Answer Counts Per Question' } },
+            scales: { x: { stacked: false }, y: { beginAtZero: true } }
+        }
+    });
+
+    const freeTexts = {{ free_texts | tojson }};
+    if (freeTexts.length) {
+        const container = document.getElementById('freeTextContainer');
+        const list = document.createElement('ul');
+        freeTexts.forEach(t => {
+            const li = document.createElement('li');
+            li.textContent = t;
+            list.appendChild(li);
+        });
+        container.innerHTML = '<h3>Free Text Responses</h3>';
+        container.appendChild(list);
+    }
+
+    const suggestions = document.getElementById('analysisSuggestions');
+    suggestions.innerHTML = '<h3>Further Analysis Ideas</h3>' +
+        '<ul>' +
+        '<li>Track changes in category scores over time.</li>' +
+        '<li>Compare averages across different user groups.</li>' +
+        '<li>Look for correlations between questions.</li>' +
+        '</ul>';
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow exporting survey results to CSV
- show category totals and per-question counts in area charts
- list free-text responses on results page
- add logout link to results page
- style anchor elements as secondary buttons
- add titles to admin charts and make per-question chart multi-bar
- compute average scores and suggestions for further analysis
- charts now render in resizable containers

## Testing
- `pytest -q`
