### PR TITLE
Increase width of response bars on results page

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -239,7 +239,10 @@
             const qid = Object.keys(questionCounts)[qidx];
             return questionCounts[qid][ans] || 0;
         }),
-        backgroundColor: pickColor(idx)
+        backgroundColor: pickColor(idx),
+        barThickness: 30,
+        barPercentage: 1.0,
+        categoryPercentage: 0.8
     }));
     const ctxQ = document.getElementById('questionChart').getContext('2d');
     const questionChart = new Chart(ctxQ, {


### PR DESCRIPTION
## Summary
- tweak the `Responses per Question` bar chart to make bars thicker

## Testing
- `pytest -q`
