### PR TITLE
Move results table and hide columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ def admin_results():
                     question_counts[qid][val] = question_counts[qid].get(val, 0) + 1
         processed_results.append(row_dict)
 
-    headers = ["timestamp", "id"] + [f"Q{qid}" for qid in q_map.keys()] + list(aggregate_scores.keys())
+    headers = [f"Q{qid}" for qid in q_map.keys()] + list(aggregate_scores.keys())
     averages = {g: (aggregate_scores[g]/len(results) if results else 0) for g in aggregate_scores}
 
     def _corr(xs, ys):

--- a/templates/results.html
+++ b/templates/results.html
@@ -85,32 +85,6 @@
         </div>
         {% endif %}
 
-        <input type="text" id="filterInput" placeholder="Filter results" style="margin-top:10px;">
-        {% if results %}
-        <div class="table-container" style="overflow-x:auto; margin-top:20px;">
-
-            <table id="resultsTable">
-                <thead>
-                    <tr>
-                        {% for h in headers %}
-                        <th>{{ q_map.get(h, h) }}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody>
-                {% for row in results %}
-                    <tr>
-                        {% for h in headers %}
-                        <td>{{ row[h] }}</td>
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-        {% else %}
-            <p>No survey results found.</p>
-        {% endif %}
 
 
         <div class="charts-row" style="margin-top:20px;">
@@ -163,6 +137,33 @@
                 </tbody>
             </table>
         </div>
+        {% endif %}
+
+        <input type="text" id="filterInput" placeholder="Filter results" style="margin-top:10px;">
+        {% if results %}
+        <div class="table-container" style="overflow-x:auto; margin-top:20px;">
+
+            <table id="resultsTable">
+                <thead>
+                    <tr>
+                        {% for h in headers %}
+                        <th>{{ q_map.get(h, h) }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                {% for row in results %}
+                    <tr>
+                        {% for h in headers %}
+                        <td>{{ row[h] }}</td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+            <p>No survey results found.</p>
         {% endif %}
 
     </div>


### PR DESCRIPTION
## Summary
- move the submissions table to the bottom of the results page
- hide `timestamp` and `id` columns on results page

## Testing
- `pytest -q`