### PR TITLE
Improve Thai keyword extraction and paginate results

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,24 @@ import os
 import sqlite3
 import csv
 import io
-import json # Added json import
-from flask import Flask, request, jsonify, send_from_directory, render_template, session, redirect, url_for, Response
+import json  # Added json import
+import re
+from collections import defaultdict, Counter
+try:
+    from pythainlp.tokenize import word_tokenize as thai_word_tokenize
+except Exception:  # package may not be installed in all environments
+    thai_word_tokenize = None
+from flask import (
+    Flask,
+    request,
+    jsonify,
+    send_from_directory,
+    render_template,
+    session,
+    redirect,
+    url_for,
+    Response,
+)
 import openai
 
 try:
@@ -365,7 +381,11 @@ def admin_results():
     aggregate_scores = {"G1": 0, "G2": 0, "G3": 0, "G4": 0, "G5": 0, "G6": 0}
     question_counts = {str(q["id"]): {} for q in structure.get("questions", [])}
     free_texts = []
-    score_history = {"timestamps": [], "G1": [], "G2": [], "G3": [], "G4": [], "G5": [], "G6": []}
+    # store raw history for correlation
+    score_history_raw = {"timestamps": [], "G1": [], "G2": [], "G3": [], "G4": [], "G5": [], "G6": []}
+    # daily aggregation helpers
+    daily_totals = defaultdict(lambda: {g: 0 for g in aggregate_scores})
+    daily_counts = defaultdict(int)
     processed_results = []
     for row in results:
         row_dict = dict(row)
@@ -383,8 +403,12 @@ def admin_results():
         row_dict.update(scores)
         for g in aggregate_scores:
             aggregate_scores[g] += scores[g]
-            score_history[g].append(scores[g])
-        score_history["timestamps"].append(row_dict["timestamp"])
+            score_history_raw[g].append(scores[g])
+        score_history_raw["timestamps"].append(row_dict["timestamp"])
+        day = row_dict["timestamp"][:10]
+        daily_counts[day] += 1
+        for g in aggregate_scores:
+            daily_totals[day][g] += scores[g]
         for q in structure.get("questions", []):
             qid = str(q.get("id"))
             val = answers.get(qid)
@@ -399,6 +423,21 @@ def admin_results():
                 if val is not None:
                     question_counts[qid][val] = question_counts[qid].get(val, 0) + 1
         processed_results.append(row_dict)
+
+    # build daily score history averaging scores per day
+    sorted_days = sorted(daily_totals.keys())
+    score_history = {"dates": sorted_days}
+    for g in aggregate_scores:
+        score_history[g] = [daily_totals[d][g] / daily_counts[d] for d in sorted_days]
+
+    # keyword summary for free text responses
+    keyword_counts = Counter()
+    for text in free_texts:
+        if thai_word_tokenize:
+            words = thai_word_tokenize(text, engine="newmm")
+        else:
+            words = re.findall(r"\b\w+\b", text)
+        keyword_counts.update([w.strip().lower() for w in words if len(w.strip()) > 1])
 
     headers = [f"Q{qid}" for qid in q_map.keys()] + list(aggregate_scores.keys())
     averages = {g: (aggregate_scores[g]/len(results) if results else 0) for g in aggregate_scores}
@@ -416,7 +455,7 @@ def admin_results():
         return num/denom if denom else 0
 
     groups = list(aggregate_scores.keys())
-    correlations = {g1: {g2: _corr(score_history[g1], score_history[g2]) for g2 in groups} for g1 in groups}
+    correlations = {g1: {g2: _corr(score_history_raw[g1], score_history_raw[g2]) for g2 in groups} for g1 in groups}
     return render_template(
         'results.html',
         results=processed_results,
@@ -426,6 +465,7 @@ def admin_results():
         q_map=q_map,
         question_counts=question_counts,
         free_texts=free_texts,
+        keyword_counts=dict(keyword_counts),
         score_history=score_history,
         correlations=correlations
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai
 Flask
 flask-cors
 python-dotenv
+pythainlp

--- a/templates/results.html
+++ b/templates/results.html
@@ -166,6 +166,7 @@
                 </tbody>
             </table>
         </div>
+        <div id="paginationControls" style="margin-top:10px;"></div>
         {% else %}
             <p>No survey results found.</p>
         {% endif %}
@@ -175,27 +176,69 @@
     <script>
     const filterInput = document.getElementById('filterInput');
     const table = document.getElementById('resultsTable');
+    const pagination = document.getElementById('paginationControls');
+    const allRows = Array.from(table.querySelectorAll('tbody tr'));
+    let filteredRows = allRows.slice();
+    const rowsPerPage = 100;
+    let currentPage = 1;
 
-    function filterRows() {
-        const query = filterInput.value.toLowerCase();
-        const rows = table.querySelectorAll('tbody tr');
-        rows.forEach(r => {
-            const text = r.textContent.toLowerCase();
-            r.style.display = text.includes(query) ? '' : 'none';
-        });
+    const prevBtn = document.createElement('button');
+    prevBtn.textContent = 'Previous';
+    const nextBtn = document.createElement('button');
+    nextBtn.textContent = 'Next';
+    const pageInfo = document.createElement('span');
+    pageInfo.style.margin = '0 10px';
+    pagination.appendChild(prevBtn);
+    pagination.appendChild(pageInfo);
+    pagination.appendChild(nextBtn);
+
+    function updatePagination() {
+        const totalPages = Math.ceil(filteredRows.length / rowsPerPage) || 1;
+        prevBtn.disabled = currentPage <= 1;
+        nextBtn.disabled = currentPage >= totalPages;
+        pageInfo.textContent = `Page ${currentPage} of ${totalPages}`;
+        const start = (currentPage - 1) * rowsPerPage;
+        const end = start + rowsPerPage;
+        allRows.forEach(r => (r.style.display = 'none'));
+        filteredRows.slice(start, end).forEach(r => (r.style.display = ''));
     }
 
-    filterInput.addEventListener('input', filterRows);
+    prevBtn.addEventListener('click', () => {
+        if (currentPage > 1) {
+            currentPage--;
+            updatePagination();
+        }
+    });
+    nextBtn.addEventListener('click', () => {
+        const totalPages = Math.ceil(filteredRows.length / rowsPerPage) || 1;
+        if (currentPage < totalPages) {
+            currentPage++;
+            updatePagination();
+        }
+    });
+
+    function applyFilter() {
+        const query = filterInput.value.toLowerCase();
+        filteredRows = allRows.filter(r => r.textContent.toLowerCase().includes(query));
+        currentPage = 1;
+        updatePagination();
+    }
+
+    filterInput.addEventListener('input', applyFilter);
 
     table.querySelectorAll('th').forEach((th, idx) => {
         th.addEventListener('click', () => {
-            const rows = Array.from(table.querySelectorAll('tbody tr'));
-            const sorted = rows.sort((a, b) => a.children[idx].textContent.localeCompare(b.children[idx].textContent));
+            const sorted = filteredRows.sort((a, b) => a.children[idx].textContent.localeCompare(b.children[idx].textContent));
             const tbody = table.querySelector('tbody');
             tbody.innerHTML = '';
             sorted.forEach(r => tbody.appendChild(r));
+            filteredRows = Array.from(tbody.querySelectorAll('tr'));
+            currentPage = 1;
+            updatePagination();
         });
     });
+
+    updatePagination();
 
     const colors = ['#e74c3c','#3498db','#f1c40f','#2ecc71','#9b59b6','#e67e22','#1abc9c'];
     function pickColor(i){ return colors[i % colors.length]; }
@@ -270,7 +313,7 @@
     });
 
     const scoreHistory = {{ score_history | tojson }};
-    const timeLabels = scoreHistory.timestamps.map(t => new Date(t).toLocaleDateString());
+    const timeLabels = scoreHistory.dates;
     const groups = ['G1','G2','G3','G4','G5','G6'];
     const timeDatasets = groups.map((g, idx) => ({
         label: g,
@@ -320,16 +363,16 @@
         avgChart.update();
     });
 
-    const freeTexts = {{ free_texts | tojson }};
-    if (freeTexts.length) {
+    const keywordCounts = {{ keyword_counts | tojson }};
+    if (Object.keys(keywordCounts).length) {
         const container = document.getElementById('freeTextContainer');
         const list = document.createElement('ul');
-        freeTexts.forEach(t => {
+        Object.entries(keywordCounts).sort((a,b)=>b[1]-a[1]).forEach(([word,count]) => {
             const li = document.createElement('li');
-            li.textContent = t;
+            li.textContent = `${word}: ${count}`;
             list.appendChild(li);
         });
-        container.innerHTML = '<h3>Free Text Responses</h3>';
+        container.innerHTML = '<h3>Free Text Keywords</h3>';
         container.appendChild(list);
     }
 


### PR DESCRIPTION
## Summary
- use `pythainlp` tokenizer when available for free-text keywords
- limit admin results table to 100 rows per page with navigation
- list `pythainlp` in requirements

## Testing
- `pytest -q`
