### PR TITLE
Add dynamic language selector page with flags

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,6 +131,31 @@ LANGUAGE_NAMES = {
     "ms": "Malay",
 }
 
+# Labels and flag emojis used on the language selection page
+LANGUAGE_LABELS = {
+    "en": "English",
+    "fr": "Français",
+    "th": "ไทย",
+    "my": "မြန်မာ",
+    "lo": "ລາວ",
+    "ja": "日本語",
+    "zh": "中文",
+    "ko": "한국어",
+    "ms": "Bahasa Melayu",
+}
+
+LANGUAGE_FLAGS = {
+    "en": "🇬🇧",
+    "fr": "🇫🇷",
+    "th": "🇹🇭",
+    "my": "🇲🇲",
+    "lo": "🇱🇦",
+    "ja": "🇯🇵",
+    "zh": "🇨🇳",
+    "ko": "🇰🇷",
+    "ms": "🇲🇾",
+}
+
 DB_PATH = os.path.join(os.path.dirname(__file__), 'responses.db')
 
 
@@ -151,7 +176,7 @@ def admin_required(f):
 @app.route('/')
 def index():
     """Landing page that lets the user choose a language."""
-    return send_from_directory('static', 'language_select.html')
+    return render_template('language_select.html', labels=LANGUAGE_LABELS, flags=LANGUAGE_FLAGS)
 
 @app.route('/questionnaire')
 def questionnaire():

--- a/templates/language_select.html
+++ b/templates/language_select.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Select Language</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <style>
+        #languageOptions {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+            margin-top: 2rem;
+            flex-wrap: wrap;
+        }
+        .language-option {
+            text-align: center;
+            cursor: pointer;
+            transition: transform 0.2s;
+        }
+        .language-option .icon {
+            font-size: 48px;
+        }
+        .language-option:hover {
+            transform: scale(1.1);
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Select your language</h1>
+
+    <div id="languageOptions">
+        {% for code, label in labels.items() %}
+        <div class="language-option" data-lang="{{ code }}">
+            <div class="icon" role="img" aria-label="{{ label }}">{{ flags.get(code, '') }}</div>
+            <div class="lang-label">{{ label }}</div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+
+<script>
+    document.querySelectorAll('.language-option').forEach(function(el) {
+        el.addEventListener('click', function() {
+            var lang = el.getAttribute('data-lang');
+            localStorage.setItem('language', lang);
+            window.location.href = '/questionnaire';
+        });
+    });
+</script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,6 +21,8 @@ def test_index_route(client):
     res = client.get('/')
     assert res.status_code == 200
     assert b'<!DOCTYPE html>' in res.data
+    # The landing page should contain language options
+    assert b'language-option' in res.data
 
 
 def test_submit_and_admin_results(client):


### PR DESCRIPTION
## Summary
- generate language selection page from server data
- serve new template from `/`
- assert presence of language options in tests

## Testing
- `pytest -q`